### PR TITLE
Add a comment option for use with knitr engine

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -1,10 +1,10 @@
 build_details <- function(text = '', summary = '', state = 'open', 
-                          lang = 'r', output = 'console',...){
+                          lang = 'r', output = 'console', comment = NA, ...){
   
   structure(
     paste(
     start_details(state,summary),
-    body_details(lang,capture.print(text,...)),
+    body_details(lang,capture.print(text,comment,...)),
     end_details(),
     sep='\n\n'),
     file = details_env$f_png,

--- a/R/details.R
+++ b/R/details.R
@@ -16,6 +16,7 @@
 #'  clipboard or R file editor, 
 #'  Default: c('console','clipr','file.edit','character')
 #' @param imgur logical, upload device outputs to imgur, Default: TRUE
+#' @param comment character, the prefix to be put before source code output, Default: NA 
 #' @seealso [use_details][details::use_details]
 #' @details 
 #'   To remove summary or tooltip set them to NULL.
@@ -83,7 +84,8 @@ details <- function(object,
                     open    = FALSE, 
                     lang    = 'r',
                     output  = c('console','clipr','edit','character'),
-                    imgur = TRUE
+                    imgur = TRUE,
+                    comment = NA
                     ){
   
   on.exit({
@@ -109,6 +111,7 @@ details <- function(object,
                 state   = build_state(open), 
                 lang    = lang,
                 output  = output,
+                comment = comment,
                 ...)
   
 }

--- a/R/engine.R
+++ b/R/engine.R
@@ -16,6 +16,7 @@ eng_detail <- function (options) {
   options$details.summary <- options$details.summary %n% NULL
   options$details.open <- options$details.open %n% FALSE
   options$details.imgur <- options$details.imgur %n% FALSE
+  options$details.comment <- options$details.comment %n% NA
   
   if(!is.null(options$fig.dim)){
     options$fig.width <- options$fig.dim[1]
@@ -40,6 +41,7 @@ eng_detail <- function (options) {
                   summary = options$details.summary,
                   open = options$details.open,
                   imgur = options$details.imgur,
+                  comment = options$details.comment,
                   output = 'character')
   
   if(length(attr(code,'file'))>0){

--- a/R/read.R
+++ b/R/read.R
@@ -1,5 +1,5 @@
 #' @importFrom utils capture.output
-capture.print <- function(obj,...){
+capture.print <- function(obj,comment = NA,...){
   
   if(details_env$device){
     
@@ -15,6 +15,9 @@ capture.print <- function(obj,...){
     }
         
   }
+  
+  if(!is.na(comment))
+    obj <- paste0(comment,' ',obj)
   
   paste0(obj,collapse = '\n')
 }

--- a/man/details.Rd
+++ b/man/details.Rd
@@ -6,7 +6,7 @@
 \usage{
 details(object, ..., summary = NULL, tooltip = "Click to Expand",
   open = FALSE, lang = "r", output = c("console", "clipr", "edit",
-  "character"), imgur = TRUE)
+  "character"), imgur = TRUE, comment = NA)
 }
 \arguments{
 \item{object}{object, object to put in details block}
@@ -29,6 +29,8 @@ clipboard or R file editor,
 Default: c('console','clipr','file.edit','character')}
 
 \item{imgur}{logical, upload device outputs to imgur, Default: TRUE}
+
+\item{comment}{character, the prefix to be put before source code output, Default: NA}
 }
 \value{
 character


### PR DESCRIPTION
The knitr `comment` code output chunk option is currently ignored by the `details` chunks. This is often probably the desired outcome as when input and output are separated by "details" commenting output is less important. In some cases though, having the ability to comment R output within a `details` chunk is desirable (e.g., to make output consistent when mixing `knitr` `r` chunks and `details` chunks).  